### PR TITLE
feat: extend FirewallPolicy with source filtering, group refs, and me…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Extended `FirewallPolicy` with source-side filtering fields: `source_ip_ranges`, `source_mac_addresses`, `source_port_ranges`, `source_network_id`
+- Added destination-side fields: `destination_mac_addresses`, `destination_network_id`
+- Added firewall group references: `source_port_group_id`, `destination_port_group_id`, `source_address_group_id`, `destination_address_group_id`
+- Added connection/metadata fields: `connection_state_type`, `connection_logging`, `schedule`, `match_ip_sec`
+- Normalization extracts all new fields from both flat and nested (v2 API) formats
+
 ## [1.0.5] (2026-03-09)
 
 ### Added

--- a/src/unifi_topology/model/firewall.py
+++ b/src/unifi_topology/model/firewall.py
@@ -30,6 +30,24 @@ class FirewallPolicy:
     description: str = ""
     index: int = 0
     predefined: bool = False
+    # Source-side filtering
+    source_ip_ranges: tuple[str, ...] = ()
+    source_mac_addresses: tuple[str, ...] = ()
+    source_port_ranges: tuple[str, ...] = ()
+    source_network_id: str = ""
+    # Destination-side filtering
+    destination_mac_addresses: tuple[str, ...] = ()
+    destination_network_id: str = ""
+    # Firewall group references (IDs)
+    source_port_group_id: str = ""
+    destination_port_group_id: str = ""
+    source_address_group_id: str = ""
+    destination_address_group_id: str = ""
+    # Connection state / metadata
+    connection_state_type: str = ""
+    connection_logging: bool = False
+    schedule: str = ""
+    match_ip_sec: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/unifi_topology/model/firewall_coerce.py
+++ b/src/unifi_topology/model/firewall_coerce.py
@@ -87,6 +87,63 @@ def _ip_ranges_from_nested(entry: object) -> tuple[str, ...]:
     return ()
 
 
+def _source_ip_ranges_from_nested(entry: object) -> tuple[str, ...]:
+    """Extract IP ranges from nested source dict."""
+    src = first_attr(entry, "source")
+    if not isinstance(src, dict):
+        return ()
+    ips = src.get("ips")
+    if isinstance(ips, list):
+        return tuple(str(ip) for ip in ips if ip is not None)
+    return ()
+
+
+def _source_port_ranges_from_nested(entry: object) -> tuple[str, ...]:
+    """Extract port ranges from nested source dict."""
+    src = first_attr(entry, "source")
+    if not isinstance(src, dict):
+        return ()
+    if src.get("port_matching_type") == "ANY":
+        return ()
+    port = src.get("port")
+    if port is not None:
+        return (str(port),)
+    return ()
+
+
+def _mac_addresses_from_nested(entry: object, key: str) -> tuple[str, ...]:
+    """Extract MAC addresses from a nested dict."""
+    nested = first_attr(entry, key)
+    if not isinstance(nested, dict):
+        return ()
+    macs = nested.get("mac_addresses")
+    if isinstance(macs, list):
+        return tuple(str(m) for m in macs if m is not None)
+    return ()
+
+
+def _network_id_from_nested(entry: object, key: str) -> str:
+    """Extract network_id from a nested dict."""
+    nested = first_attr(entry, key)
+    if isinstance(nested, dict):
+        nid = nested.get("network_id")
+        if nid is not None:
+            return str(nid)
+    return ""
+
+
+def _group_id_from_nested(
+    entry: object, key: str, group_key: str,
+) -> str:
+    """Extract a firewall group ID from a nested dict."""
+    nested = first_attr(entry, key)
+    if isinstance(nested, dict):
+        gid = nested.get(group_key)
+        if gid is not None:
+            return str(gid)
+    return ""
+
+
 def _build_policy(entry: object, policy_id: str) -> FirewallPolicy:
     """Build a FirewallPolicy from a raw entry with a validated ID."""
     source_zone, dest_zone = _resolve_zone_ids(entry)
@@ -97,6 +154,12 @@ def _build_policy(entry: object, policy_id: str) -> FirewallPolicy:
     ip_ranges = _as_tuple_str(first_attr(entry, "ip_ranges", "addresses", "dst_address"))
     if not ip_ranges:
         ip_ranges = _ip_ranges_from_nested(entry)
+    source_ip_ranges = _as_tuple_str(first_attr(entry, "source_ip_ranges", "src_address"))
+    if not source_ip_ranges:
+        source_ip_ranges = _source_ip_ranges_from_nested(entry)
+    source_port_ranges = _as_tuple_str(first_attr(entry, "source_port_ranges", "src_port"))
+    if not source_port_ranges:
+        source_port_ranges = _source_port_ranges_from_nested(entry)
     return FirewallPolicy(
         id=policy_id,
         name=_as_str(first_attr(entry, "name", "description", "policy_name")),
@@ -110,6 +173,20 @@ def _build_policy(entry: object, policy_id: str) -> FirewallPolicy:
         description=_as_str(first_attr(entry, "description", "desc")),
         index=as_int(first_attr(entry, "index", "rule_index", "order", "position")),
         predefined=as_bool(first_attr(entry, "predefined", "is_predefined")),
+        source_ip_ranges=source_ip_ranges,
+        source_mac_addresses=_mac_addresses_from_nested(entry, "source"),
+        source_port_ranges=source_port_ranges,
+        source_network_id=_network_id_from_nested(entry, "source"),
+        destination_mac_addresses=_mac_addresses_from_nested(entry, "destination"),
+        destination_network_id=_network_id_from_nested(entry, "destination"),
+        source_port_group_id=_group_id_from_nested(entry, "source", "port_group_id"),
+        destination_port_group_id=_group_id_from_nested(entry, "destination", "port_group_id"),
+        source_address_group_id=_group_id_from_nested(entry, "source", "address_group_id"),
+        destination_address_group_id=_group_id_from_nested(entry, "destination", "address_group_id"),
+        connection_state_type=_as_str(first_attr(entry, "connection_state_type", "state_type")),
+        connection_logging=as_bool(first_attr(entry, "connection_logging", "logging")),
+        schedule=_as_str(first_attr(entry, "schedule")),
+        match_ip_sec=_as_str(first_attr(entry, "match_ip_sec", "ipsec")),
     )
 
 

--- a/tests/test_firewall_coerce.py
+++ b/tests/test_firewall_coerce.py
@@ -182,6 +182,278 @@ class TestNormalizePolicies:
         assert policies[0].source_zone_id == "flat_src"
         assert policies[0].destination_zone_id == "flat_dst"
 
+    def test_source_ip_ranges_flat(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source_zone_id": "z1",
+                "destination_zone_id": "z2",
+                "source_ip_ranges": ["10.0.0.0/8"],
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].source_ip_ranges == ("10.0.0.0/8",)
+
+    def test_source_ip_ranges_nested(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source": {"zone_id": "z1", "ips": ["192.168.1.0/24"]},
+                "destination": {"zone_id": "z2"},
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].source_ip_ranges == ("192.168.1.0/24",)
+
+    def test_source_port_ranges_nested(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source": {
+                    "zone_id": "z1",
+                    "port": "8080",
+                    "port_matching_type": "SPECIFIC",
+                },
+                "destination": {"zone_id": "z2"},
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].source_port_ranges == ("8080",)
+
+    def test_source_port_ranges_any(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source": {
+                    "zone_id": "z1",
+                    "port_matching_type": "ANY",
+                },
+                "destination": {"zone_id": "z2"},
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].source_port_ranges == ()
+
+    def test_mac_addresses(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source": {
+                    "zone_id": "z1",
+                    "mac_addresses": ["AA:BB:CC:DD:EE:FF"],
+                },
+                "destination": {
+                    "zone_id": "z2",
+                    "mac_addresses": ["11:22:33:44:55:66"],
+                },
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].source_mac_addresses == ("AA:BB:CC:DD:EE:FF",)
+        assert policies[0].destination_mac_addresses == ("11:22:33:44:55:66",)
+
+    def test_network_ids(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source": {"zone_id": "z1", "network_id": "net1"},
+                "destination": {"zone_id": "z2", "network_id": "net2"},
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].source_network_id == "net1"
+        assert policies[0].destination_network_id == "net2"
+
+    def test_group_ids(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source": {
+                    "zone_id": "z1",
+                    "port_group_id": "pg1",
+                    "address_group_id": "ag1",
+                },
+                "destination": {
+                    "zone_id": "z2",
+                    "port_group_id": "pg2",
+                    "address_group_id": "ag2",
+                },
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].source_port_group_id == "pg1"
+        assert policies[0].destination_port_group_id == "pg2"
+        assert policies[0].source_address_group_id == "ag1"
+        assert policies[0].destination_address_group_id == "ag2"
+
+    def test_connection_state_type(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source_zone_id": "z1",
+                "destination_zone_id": "z2",
+                "connection_state_type": "ESTABLISHED",
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].connection_state_type == "ESTABLISHED"
+
+    def test_connection_logging(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source_zone_id": "z1",
+                "destination_zone_id": "z2",
+                "connection_logging": True,
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].connection_logging is True
+
+    def test_schedule(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source_zone_id": "z1",
+                "destination_zone_id": "z2",
+                "schedule": "weekdays-only",
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].schedule == "weekdays-only"
+
+    def test_match_ip_sec(self):
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source_zone_id": "z1",
+                "destination_zone_id": "z2",
+                "match_ip_sec": "MATCH_IPSEC",
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        assert policies[0].match_ip_sec == "MATCH_IPSEC"
+
+    def test_defaults_for_new_fields(self):
+        """New fields default to empty when not present in raw data."""
+        raw = [
+            {
+                "_id": "p1",
+                "name": "x",
+                "enabled": True,
+                "action": "ALLOW",
+                "source_zone_id": "z1",
+                "destination_zone_id": "z2",
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        p = policies[0]
+        assert p.source_ip_ranges == ()
+        assert p.source_mac_addresses == ()
+        assert p.source_port_ranges == ()
+        assert p.source_network_id == ""
+        assert p.destination_mac_addresses == ()
+        assert p.destination_network_id == ""
+        assert p.source_port_group_id == ""
+        assert p.destination_port_group_id == ""
+        assert p.source_address_group_id == ""
+        assert p.destination_address_group_id == ""
+        assert p.connection_state_type == ""
+        assert p.connection_logging is False
+        assert p.schedule == ""
+        assert p.match_ip_sec == ""
+
+    def test_full_v2_nested_entry(self):
+        """Realistic v2 API entry with many nested fields."""
+        raw = [
+            {
+                "_id": "p1",
+                "name": "Restrict IoT",
+                "enabled": True,
+                "action": "ALLOW",
+                "protocol": "tcp",
+                "source": {
+                    "zone_id": "z_iot",
+                    "ips": ["10.10.0.0/16"],
+                    "mac_addresses": ["AA:BB:CC:DD:EE:FF"],
+                    "port": "1024",
+                    "port_matching_type": "SPECIFIC",
+                    "network_id": "net_iot",
+                    "port_group_id": "pg_src",
+                    "address_group_id": "ag_src",
+                },
+                "destination": {
+                    "zone_id": "z_lan",
+                    "ips": ["192.168.1.0/24"],
+                    "mac_addresses": ["11:22:33:44:55:66"],
+                    "port": "443",
+                    "port_matching_type": "SPECIFIC",
+                    "network_id": "net_lan",
+                    "port_group_id": "pg_dst",
+                    "address_group_id": "ag_dst",
+                },
+                "connection_state_type": "NEW",
+                "connection_logging": True,
+                "schedule": "work-hours",
+                "match_ip_sec": "MATCH_IPSEC",
+                "index": 500,
+                "predefined": False,
+            },
+        ]
+        policies = normalize_firewall_policies(raw)
+        p = policies[0]
+        assert p.source_zone_id == "z_iot"
+        assert p.destination_zone_id == "z_lan"
+        assert p.source_ip_ranges == ("10.10.0.0/16",)
+        assert p.ip_ranges == ("192.168.1.0/24",)
+        assert p.source_mac_addresses == ("AA:BB:CC:DD:EE:FF",)
+        assert p.destination_mac_addresses == ("11:22:33:44:55:66",)
+        assert p.source_port_ranges == ("1024",)
+        assert p.port_ranges == ("443",)
+        assert p.source_network_id == "net_iot"
+        assert p.destination_network_id == "net_lan"
+        assert p.source_port_group_id == "pg_src"
+        assert p.destination_port_group_id == "pg_dst"
+        assert p.source_address_group_id == "ag_src"
+        assert p.destination_address_group_id == "ag_dst"
+        assert p.connection_state_type == "NEW"
+        assert p.connection_logging is True
+        assert p.schedule == "work-hours"
+        assert p.match_ip_sec == "MATCH_IPSEC"
+
 
 class TestNormalizeGroups:
     def test_basic(self):


### PR DESCRIPTION
…tadata

Add 14 new fields to FirewallPolicy covering source-side filtering (IPs, MACs, ports, network), firewall group references (port and address groups for both directions), and connection metadata (state type, logging, schedule, IPSec matching).

All fields default to empty values for backward compatibility. The normalization layer extracts them from both flat and nested v2 API response formats.

## Summary

<!-- Brief description of the changes -->

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Checklist

- [ ] `make ci` passes
- [ ] Tests added/updated for behavior changes
- [ ] Type annotations included
