### PR TITLE
Cache UnifiClient instances to avoid repeated logins

### DIFF
--- a/src/unifi_topology/adapters/__init__.py
+++ b/src/unifi_topology/adapters/__init__.py
@@ -3,6 +3,7 @@
 from .config import Config
 from .dns import resolve_hostnames
 from .unifi import (
+    clear_client_cache,
     fetch_clients,
     fetch_devices,
     fetch_firewall_groups,
@@ -18,6 +19,7 @@ from .unifi_api import UnifiWriteError
 __all__ = [
     "Config",
     "UnifiWriteError",
+    "clear_client_cache",
     "fetch_clients",
     "fetch_devices",
     "fetch_firewall_groups",

--- a/src/unifi_topology/adapters/unifi.py
+++ b/src/unifi_topology/adapters/unifi.py
@@ -390,6 +390,31 @@ def _create_client(config: Config, *, is_udm_pro: bool) -> UnifiClient:
     )
 
 
+_client_cache: dict[tuple[str, str, bool], UnifiClient] = {}
+
+
+def _get_or_create_client(config: Config, *, is_udm_pro: bool) -> UnifiClient:
+    """Get a cached client or create a new one."""
+    cache_key = (config.url, config.user, is_udm_pro)
+    client = _client_cache.get(cache_key)
+    if client is not None:
+        return client
+    client = _create_client(config, is_udm_pro=is_udm_pro)
+    _client_cache[cache_key] = client
+    return client
+
+
+def _evict_client(config: Config, *, is_udm_pro: bool) -> None:
+    """Remove a cached client entry."""
+    cache_key = (config.url, config.user, is_udm_pro)
+    _client_cache.pop(cache_key, None)
+
+
+def clear_client_cache() -> None:
+    """Clear all cached client sessions."""
+    _client_cache.clear()
+
+
 def _is_rate_limited(exc: Exception) -> bool:
     return "429" in str(exc)
 
@@ -404,14 +429,16 @@ def _connect_and_fetch(
     On ``UnifiAuthError`` that isn't rate-limited, retries with
     legacy auth.  Any other error (rate limit, network, etc.) propagates
     to the caller's stale-cache handler.
+
+    Reuses cached client sessions per config to avoid repeated logins.
     """
     try:
-        client = _create_client(config, is_udm_pro=True)
+        client = _get_or_create_client(config, is_udm_pro=True)
     except UnifiAuthError as exc:
         if _is_rate_limited(exc):
             raise
         logger.debug("UDM Pro authentication failed, retrying legacy auth")
-        client = _create_client(config, is_udm_pro=False)
+        client = _get_or_create_client(config, is_udm_pro=False)
 
     return _call_with_retries(operation, fetch_fn(client))
 
@@ -681,8 +708,9 @@ def toggle_firewall_policy(
 ) -> None:
     """Toggle a firewall policy's enabled state and invalidate cache."""
     site_name = site or config.site
-    client = _create_client(config, is_udm_pro=True)
+    client = _get_or_create_client(config, is_udm_pro=True)
     client.update_firewall_policy(site_name, policy_id, {"enabled": enabled})
+    clear_client_cache()
     invalidate_cache(config, site=site)
 
 
@@ -695,6 +723,7 @@ def swap_firewall_policy_order(
 ) -> None:
     """Swap the index of two firewall policies and invalidate cache."""
     site_name = site or config.site
-    client = _create_client(config, is_udm_pro=True)
+    client = _get_or_create_client(config, is_udm_pro=True)
     client.swap_firewall_policy_order(site_name, policy_id_a, policy_id_b)
+    clear_client_cache()
     invalidate_cache(config, site=site)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 SRC = Path(__file__).resolve().parents[1] / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
@@ -12,10 +14,16 @@ for name in list(sys.modules):
         del sys.modules[name]
 
 
+@pytest.fixture(autouse=True)
+def _clear_client_cache() -> None:
+    """Clear the UniFi client cache between tests."""
+    from unifi_topology.adapters.unifi import clear_client_cache
+
+    clear_client_cache()
+
+
 def pytest_collection_modifyitems(items: list) -> None:
     """Automatically mark tests without specific markers as unit tests."""
-    import pytest
-
     specific_markers = {"integration", "contract", "acceptance"}
     for item in items:
         item_markers = {marker.name for marker in item.iter_markers()}

--- a/tests/test_unifi.py
+++ b/tests/test_unifi.py
@@ -519,3 +519,175 @@ def test_toggle_invalidates_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(unifi, "_create_client", lambda *_a, **_k: FakeClient())
     unifi.toggle_firewall_policy(config, "p1", enabled=False)
     assert not cache_path.exists()
+
+
+# ------------------------------------------------------------------
+# Client cache
+# ------------------------------------------------------------------
+
+
+def test_client_cache_reuses_same_client(monkeypatch):
+    """Two consecutive _get_or_create_client calls reuse the same client."""
+    instances: list[object] = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            instances.append(self)
+
+    monkeypatch.setattr(unifi, "UnifiClient", FakeClient)
+    config = Config(
+        url="https://example",
+        site="default",
+        user="user",
+        password="pass",
+        verify_ssl=True,
+    )
+    client_a = unifi._get_or_create_client(config, is_udm_pro=True)
+    client_b = unifi._get_or_create_client(config, is_udm_pro=True)
+    assert client_a is client_b
+    assert len(instances) == 1
+
+
+def test_clear_client_cache_forces_new_client(monkeypatch):
+    """After clear_client_cache(), next call creates a fresh client."""
+    instances: list[object] = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            instances.append(self)
+
+    monkeypatch.setattr(unifi, "UnifiClient", FakeClient)
+    config = Config(
+        url="https://example",
+        site="default",
+        user="user",
+        password="pass",
+        verify_ssl=True,
+    )
+    client_a = unifi._get_or_create_client(config, is_udm_pro=True)
+    unifi.clear_client_cache()
+    client_b = unifi._get_or_create_client(config, is_udm_pro=True)
+    assert client_a is not client_b
+    assert len(instances) == 2
+
+
+def test_different_configs_get_different_clients(monkeypatch):
+    """Different config credentials produce different cached clients."""
+    instances: list[object] = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            instances.append(self)
+
+    monkeypatch.setattr(unifi, "UnifiClient", FakeClient)
+    config_a = Config(
+        url="https://example-a",
+        site="default",
+        user="user_a",
+        password="pass",
+        verify_ssl=True,
+    )
+    config_b = Config(
+        url="https://example-b",
+        site="default",
+        user="user_b",
+        password="pass",
+        verify_ssl=True,
+    )
+    client_a = unifi._get_or_create_client(config_a, is_udm_pro=True)
+    client_b = unifi._get_or_create_client(config_b, is_udm_pro=True)
+    assert client_a is not client_b
+    assert len(instances) == 2
+
+
+def test_connect_and_fetch_reuses_cached_client(monkeypatch, tmp_path):
+    """Multiple _connect_and_fetch calls share a single client."""
+    monkeypatch.setenv("UNIFI_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIFI_CACHE_TTL_SECONDS", "0")
+    create_calls = {"count": 0}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            create_calls["count"] += 1
+
+        def get_devices(self, site, *, detailed=False):
+            return [{"name": "dev"}]
+
+        def get_clients(self, site):
+            return [{"name": "cli"}]
+
+    monkeypatch.setattr(unifi, "UnifiClient", FakeClient)
+    config = Config(
+        url="https://example",
+        site="default",
+        user="user",
+        password="pass",
+        verify_ssl=True,
+    )
+    unifi.fetch_devices(config, use_cache=False)
+    unifi.fetch_clients(config, use_cache=False)
+    assert create_calls["count"] == 1
+
+
+def test_toggle_clears_client_cache(monkeypatch, tmp_path):
+    """toggle_firewall_policy clears the client cache."""
+    monkeypatch.setenv("UNIFI_CACHE_DIR", str(tmp_path))
+    create_calls = {"count": 0}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            create_calls["count"] += 1
+
+        def update_firewall_policy(self, site, policy_id, updates):
+            return {"_id": policy_id}
+
+        def get_devices(self, site, *, detailed=False):
+            return [{"name": "dev"}]
+
+    monkeypatch.setattr(unifi, "UnifiClient", FakeClient)
+    config = Config(
+        url="https://example",
+        site="default",
+        user="user",
+        password="pass",
+        verify_ssl=True,
+    )
+    unifi.fetch_devices(config, use_cache=False)
+    assert create_calls["count"] == 1
+    unifi.toggle_firewall_policy(config, "p1", enabled=False)
+    # toggle reuses cached client, then clears cache
+    assert create_calls["count"] == 1
+    unifi.fetch_devices(config, use_cache=False)
+    # new client created after cache was cleared
+    assert create_calls["count"] == 2
+
+
+def test_swap_clears_client_cache(monkeypatch, tmp_path):
+    """swap_firewall_policy_order clears the client cache."""
+    monkeypatch.setenv("UNIFI_CACHE_DIR", str(tmp_path))
+    create_calls = {"count": 0}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            create_calls["count"] += 1
+
+        def swap_firewall_policy_order(self, site, id_a, id_b):
+            pass
+
+        def get_devices(self, site, *, detailed=False):
+            return [{"name": "dev"}]
+
+    monkeypatch.setattr(unifi, "UnifiClient", FakeClient)
+    config = Config(
+        url="https://example",
+        site="default",
+        user="user",
+        password="pass",
+        verify_ssl=True,
+    )
+    unifi.fetch_devices(config, use_cache=False)
+    assert create_calls["count"] == 1
+    unifi.swap_firewall_policy_order(config, "pa", "pb")
+    assert create_calls["count"] == 1
+    unifi.fetch_devices(config, use_cache=False)
+    assert create_calls["count"] == 2


### PR DESCRIPTION
## Summary

- Cache `UnifiClient` instances per `(url, user, is_udm_pro)` tuple so that consecutive `fetch_*()` calls reuse the same authenticated session instead of logging in each time
- Prevents 429 rate-limit errors from the UniFi controller when multiple data fetches run in sequence (e.g., `fetch_devices` + `fetch_clients` + `fetch_networks`)
- Clear cache after write operations (`toggle_firewall_policy`, `swap_firewall_policy_order`) since writes may change CSRF state
- Export `clear_client_cache()` for explicit cache control

## Test plan

- [x] Verify same config returns same client instance
- [x] Verify `clear_client_cache()` forces fresh client on next call
- [x] Verify different configs get separate cached clients
- [x] Verify write operations clear the cache
- [x] All 670 existing tests pass