### PR TITLE
Add API model code aliases for 3 missing devices

### DIFF
--- a/scripts/scrape_models.py
+++ b/scripts/scrape_models.py
@@ -73,6 +73,8 @@ PLATFORM_TO_SKU: dict[str, str] = {
     "U7IWP": "U7-Pro-Wall",
     "U7LR": "U7-LR",
     "U7LT": "U6+",
+    "UAPA693": "U7-Lite",
+    "G7LT": "U7-Lite",
     "U7MP": "U7-Pro-Max",
     "U7MSH": "U7-Mesh",
     "U7NHD": "UAP-nanoHD",
@@ -113,6 +115,8 @@ PLATFORM_TO_SKU: dict[str, str] = {
     "UXGENT": "UXG-Enterprise",
     "UXGPRO": "UXG-Pro-US",
     "UXGPROV2": "UXG-Pro-US",
+    "UDMA6A8": "UCG-Fiber",
+    "UCGF": "UCG-Fiber",
     # ── Switches ────────────────────────────────────────────────────
     "US8": "USW-8",
     "US8P60": "USW-8-PoE",
@@ -136,6 +140,8 @@ PLATFORM_TO_SKU: dict[str, str] = {
     "US6XG150": "USW-Pro-Aggregation",
     "USC8": "USW-Ultra-60W",
     "USC8P450": "USW-Ultra-210W",
+    "USWED37": "USW-Ultra-210W",
+    "USM25G8P": "USW-Ultra-210W",
     "USF5P": "USW-Flex",
     "USFXG": "USW-Pro-XG-Aggregation",
     "USL8LP": "USW-Lite-8-PoE",
@@ -402,6 +408,26 @@ def _merge_firmware(
     _print_firmware_stats(matched, unmatched)
 
 
+def _ensure_sku_aliases(models: dict[str, ModelEntry]) -> None:
+    """Create entries for PLATFORM_TO_SKU codes not already in models.
+
+    The firmware merge only processes codes present in the firmware API.
+    Controller model codes and shortname aliases that aren't firmware
+    platform codes still need entries so ``lookup_model_name`` resolves them.
+    """
+    added = 0
+    for code, sku in PLATFORM_TO_SKU.items():
+        if code in models:
+            continue
+        store = models.get(sku)
+        if store is None:
+            continue
+        models[code] = dict(store)
+        added += 1
+    if added:
+        print(f"  SKU aliases: {added} added from PLATFORM_TO_SKU")
+
+
 def _print_firmware_stats(matched: int, unmatched: list[str]) -> None:
     print(f"  Firmware: {matched} matched, {len(unmatched)} unmatched")
     if unmatched:
@@ -427,6 +453,7 @@ def scrape() -> dict[str, Any]:
     platforms = _fetch_firmware_platforms(session)
     print(f"  {len(platforms)} firmware platforms")
     _merge_firmware(models, platforms)
+    _ensure_sku_aliases(models)
 
     return {
         "_meta": {

--- a/src/unifi_topology/assets/models.json
+++ b/src/unifi_topology/assets/models.json
@@ -73,6 +73,13 @@
         "guide": "https://ui.com/qig/efg"
       }
     },
+    "G7LT": {
+      "name": "Access Point U7 Lite",
+      "url": "https://store.ui.com/us/en/products/u7-lite",
+      "docs": {
+        "guide": "https://ui.com/qig/u7-lite"
+      }
+    },
     "Official UniFi Hosting": {
       "name": "Official UniFi Hosting",
       "url": "https://store.ui.com/us/en/products/unifi-hosting"
@@ -535,7 +542,11 @@
       "firmware_changelog": "https://fw-update.ui.com/api/firmware/7063ccd6-22c1-496e-aa51-ee4e0ed6b03e/changelog"
     },
     "UAPA693": {
-      "name": "UAPA693",
+      "name": "Access Point U7 Lite",
+      "url": "https://store.ui.com/us/en/products/u7-lite",
+      "docs": {
+        "guide": "https://ui.com/qig/u7-lite"
+      },
       "firmware_changelog": "https://fw-update.ui.com/api/firmware/c9472971-bb24-4113-90e6-03721b79bd27/changelog"
     },
     "UAPA697": {
@@ -698,6 +709,10 @@
         "guide": "https://ui.com/qig/ucg-ultra"
       }
     },
+    "UCGF": {
+      "name": "Cloud Gateway Fiber",
+      "url": "https://store.ui.com/us/en/products/ucg-fiber"
+    },
     "UCI": {
       "name": "UCI",
       "firmware_changelog": "https://fw-update.ui.com/api/firmware/41fc5131-d067-4f27-8d2d-940f85702c4d/changelog"
@@ -808,6 +823,10 @@
         "guide": "https://ui.com/qig/udm-pro-max"
       },
       "firmware_changelog": "https://fw-update.ui.com/api/firmware/02ea9883-e84e-42f0-9083-695cd0313e4d/changelog"
+    },
+    "UDMA6A8": {
+      "name": "Cloud Gateway Fiber",
+      "url": "https://store.ui.com/us/en/products/ucg-fiber"
     },
     "UDMB": {
       "name": "Dream Machine Special Edition",
@@ -1300,6 +1319,10 @@
       },
       "firmware_changelog": "https://fw-update.ui.com/api/firmware/4345dd46-e992-45d0-afb9-72ca1221dfc7/changelog"
     },
+    "USM25G8P": {
+      "name": "Switch Ultra 210W",
+      "url": "https://store.ui.com/us/en/products/usw-ultra-210w"
+    },
     "USM8P": {
       "name": "Switch Pro 8 PoE",
       "url": "https://store.ui.com/us/en/products/usw-pro-8-poe",
@@ -1784,7 +1807,8 @@
       "firmware_changelog": "https://fw-update.ui.com/api/firmware/73ab7485-10a0-4e46-b6cc-cbd943ead22c/changelog"
     },
     "USWED37": {
-      "name": "USWED37",
+      "name": "Switch Ultra 210W",
+      "url": "https://store.ui.com/us/en/products/usw-ultra-210w",
       "firmware_changelog": "https://fw-update.ui.com/api/firmware/2dd96da7-c901-4842-89f9-0ec3937099d5/changelog"
     },
     "USWED42": {


### PR DESCRIPTION
## Summary

Adds API model code and shortname aliases for three devices that were returning empty friendly names.

| API `model` | Shortname | Friendly name |
|---|---|---|
| `UDMA6A8` | `UCGF` | Cloud Gateway Fiber |
| `UAPA693` | `G7LT` | Access Point U7 Lite |
| `USWED37` | `USM25G8P` | Switch Ultra 210W |

The product-line keys (`UCG-Fiber`, `U7-Lite`, `USW-Ultra-210W`) were already in the table but the controller API returns internal model codes that didn't match.

Fixes #23